### PR TITLE
Fix Confirme Delete to New Rails Version

### DIFF
--- a/app/views/my_admin/models/index.html.erb
+++ b/app/views/my_admin/models/index.html.erb
@@ -92,7 +92,7 @@
 													<%= I18n.t('my_admin.labels.models.edit') %>
 												<% end if @model.my_admin.can?(:update, my_admin_user) %>
 																								
-												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :model => @model.title), :class => "btn btn-mini btn-danger", :data => {:confirm => I18n.t('my_admin.messages.models.confirm_remove'}) do %>
+												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :confirm => I18n.t('my_admin.messages.models.confirm_remove', :model => @model.title), :class => "btn btn-mini btn-danger") do %>
 													<i class="icon-trash"></i>
 													<%= I18n.t('my_admin.labels.models.remove') %>
 												

--- a/app/views/my_admin/models/index.html.erb
+++ b/app/views/my_admin/models/index.html.erb
@@ -92,7 +92,7 @@
 													<%= I18n.t('my_admin.labels.models.edit') %>
 												<% end if @model.my_admin.can?(:update, my_admin_user) %>
 																								
-												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :confirm => I18n.t('my_admin.messages.models.confirm_remove', :model => @model.title), :class => "btn btn-mini btn-danger") do %>
+												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :model => @model.title), :class => "btn btn-mini btn-danger", :data => {:confirm => I18n.t('my_admin.messages.models.confirm_remove'}) do %>
 													<i class="icon-trash"></i>
 													<%= I18n.t('my_admin.labels.models.remove') %>
 												

--- a/app/views/my_admin/models/index.html.erb
+++ b/app/views/my_admin/models/index.html.erb
@@ -92,7 +92,7 @@
 													<%= I18n.t('my_admin.labels.models.edit') %>
 												<% end if @model.my_admin.can?(:update, my_admin_user) %>
 																								
-												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :confirm => I18n.t('my_admin.messages.models.confirm_remove', :model => @model.title), :class => "btn btn-mini btn-danger") do %>
+												<%= link_to(show_model_link(@application, @model, object), :method => :delete, :class => "btn btn-mini btn-danger", data: { confirm: I18n.t('my_admin.messages.models.confirm_remove', :model => @model.title)}) do %>
 													<i class="icon-trash"></i>
 													<%= I18n.t('my_admin.labels.models.remove') %>
 												


### PR DESCRIPTION
Fix Confirme Delete to New Rails Version.

Changes:

:confirm => "text" to :data => { :confirm => "text" }
